### PR TITLE
Drop the defaultMode constructor arguments

### DIFF
--- a/docs/_plugins/DualUse.md
+++ b/docs/_plugins/DualUse.md
@@ -2,7 +2,7 @@
 title: "Dual-use modifier & layer keys"
 permalink: /plugins/DualUse/
 excerpt: "Dual-use modifier and layer key plugin."
-modified: 2016-12-04T12:30:00+01:00
+modified: 2016-12-05T11:00:00+01:00
 ---
 
 {% include toc %}
@@ -62,7 +62,6 @@ behaviour applied.
 namespace Akela {
   class DualUseMods {
   public:
-    DualUseMods (uint8_t defaultMode, uint8_t defaultAction);
     DualUseMods (uint8_t defaultAction);
     DualUseMods (void);
 
@@ -71,7 +70,6 @@ namespace Akela {
   };
   class DualUseLayers {
   public:
-    DualUseLayers (uint8_t defaultMode, uint8_t defaultAction);
     DualUseLayers (uint8_t defaultAction);
     DualUseLayers (void);
 
@@ -81,14 +79,12 @@ namespace Akela {
 };
 ```
 
-Like most plugins that add new behaviour, this one can be configured to start
-with the new behaviour disabled. However, to do so, we must know what the
-disabled behaviour should be: act as a modifier, or as a normal key?
-
-With `defaultMode` set to *off*, the key will act as a normal key, sending
-either the first (the modifier or layer switch) or the second (the alternate
-key) to the host, depending on the value of `defaultAction`. If the
-`defaultMode` is *on* (the default), the key will behave as explained above.
+By default, the `DualUse` plugins will start enabled, like all other plugins.
+However, when turned off, they must be aware which of the two actions they
+should perform in off state. By default, unless otherwise specified with the
+`defaultAction` constructor argument, they will perform the second action, the
+single key action. This can be changed to be the modifier or the layer switch,
+by setting `defaultAction` to zero.
 
 It is possible to toggle the feature on and off, with the `on()` and `off()`
 methods of the appropriate object.

--- a/docs/_plugins/OneShot.md
+++ b/docs/_plugins/OneShot.md
@@ -2,7 +2,7 @@
 title: "One-shot keys"
 permalink: /plugins/OneShot/
 excerpt: "One-shot modifiers & layers"
-modified: 2016-12-04T12:15:00+01:00
+modified: 2016-12-05T11:15:00+01:00
 ---
 
 {% include toc %}
@@ -65,7 +65,6 @@ modifiers, or momentary layer keys into one-shots.
 namespace Akela {
   class OneShotMods {
   public:
-    OneShotMods (uint8_t defaultState);
     OneShotMods (void);
 
     static void on (void);
@@ -77,7 +76,6 @@ namespace Akela {
 
   class OneShotLayers {
   public:
-    OneShotLayers (uint8_t defaultState);
     OneShotLayers (void);
 
     static void on (void);

--- a/docs/_plugins/ShapeShifter.md
+++ b/docs/_plugins/ShapeShifter.md
@@ -2,7 +2,7 @@
 title: "Shifted symbol replacement"
 permalink: /plugins/ShapeShifter/
 excerpt: "Replace the shifted symbol on a number of keys."
-modified: 2016-12-04T13:05:00+01:00
+modified: 2016-12-05T11:20:00+01:00
 ---
 
 {% include toc %}
@@ -45,7 +45,6 @@ namespace Akela {
       Key original, replacement;
     } dictionary_t;
 
-    ShapeShifter (uint8_t defaultMode, const dictionary_t dictionary[]);
     ShapeShifter (const dictionary_t dictionary[]);
 
     void on (void);
@@ -53,10 +52,6 @@ namespace Akela {
   };
 };
 ```
-
-Like most plugins that add new behaviour, this one can be configured to start
-with the new behaviour disabled. In this case, no replacements will be made
-until the plugin is activated.
 
 The `on()` and `off()` methods can be called anytime, to turn the plugin on and
 off, respectively.

--- a/docs/_plugins/SpaceCadet.md
+++ b/docs/_plugins/SpaceCadet.md
@@ -33,20 +33,11 @@ select text, for example.
 static Akela::SpaceCadetShift spaceCadetShift;
 ```
 
-There are two properties one can configure: the default behaviour, and the paren
-keys. See the constructors [below](#plugin-methods) to see how to set these
-properties.
-
-The first property, `defaultMode` controls whether the new behaviour is on or
-off when the keyboard starts. It defaults to *on*, but if set to *off*, it can
-later be enabled with the `on()` method. The keymap does not need to be updated
-at all, the plugin overrides the normal `Shift` keys when the functionality is
-enabled.
-
-The other option is the keys to use for the parens. The plugin defaults to `9`
-and `0`, which, when shifted, mean the opening and closing parens in US QWERTY,
-and a lot of other layouts. If one uses an OS-side layout where the parens are
-on different keys, the `left` and `right` options are the ones to change.
+There is only one property one can configure: the keys to use for the parens.
+The plugin defaults to `9` and `0`, which, when shifted, mean the opening and
+closing parens in US QWERTY, and a lot of other layouts. If one uses an OS-side
+layout where the parens are on different keys, the `left` and `right` options
+are the ones to change.
 
 ## Plugin methods
 
@@ -54,8 +45,6 @@ on different keys, the `left` and `right` options are the ones to change.
 namespace Akela {
   class SpaceCadetShift {
   public:
-    SpaceCadetShift (uint8_t defaultMode, Key left, Key right);
-    SpaceCadetShift (uint8_t defaultMode);
     SpaceCadetShift (Key left, Key right);
     SpaceCadetShift (void);
 

--- a/lib/Akela-DualUse/src/Akela/DualUseLayers.cpp
+++ b/lib/Akela-DualUse/src/Akela/DualUseLayers.cpp
@@ -109,13 +109,10 @@ namespace Akela {
     return true;
   }
 
-  DualUseLayers::DualUseLayers (uint8_t defaultMode, uint8_t defaultAction) {
+  DualUseLayers::DualUseLayers (uint8_t defaultAction) {
     layerDefault = !!defaultAction;
 
-    if (defaultMode == Akela::Default::On)
-      event_handler_hook_add (eventHandlerHook);
-    else
-      event_handler_hook_add (disabledHook);
+    event_handler_hook_add (eventHandlerHook);
   }
 
   void

--- a/lib/Akela-DualUse/src/Akela/DualUseLayers.h
+++ b/lib/Akela-DualUse/src/Akela/DualUseLayers.h
@@ -27,9 +27,8 @@
 namespace Akela {
   class DualUseLayers {
   public:
-    DualUseLayers (uint8_t defaultMode, uint8_t defaultAction);
-    DualUseLayers (uint8_t defaultAction) : DualUseLayers (Akela::Default::Off, defaultAction) {};
-    DualUseLayers (void) : DualUseLayers (Akela::Default::On, 1) {};
+    DualUseLayers (uint8_t defaultAction);
+    DualUseLayers (void) : DualUseLayers (1) {};
 
     void on (void);
     void off (void);

--- a/lib/Akela-DualUse/src/Akela/DualUseMods.cpp
+++ b/lib/Akela-DualUse/src/Akela/DualUseMods.cpp
@@ -28,13 +28,10 @@ namespace Akela {
   static const uint8_t timeOut = DEFAULT_TIMEOUT * 2;
   static bool modifierDefault;
 
-  DualUseMods::DualUseMods (uint8_t defaultMode, uint8_t defaultAction) {
+  DualUseMods::DualUseMods (uint8_t defaultAction) {
     modifierDefault = !!defaultAction;
 
-    if (defaultMode == Akela::Default::On)
-      event_handler_hook_add (this->eventHandlerHook);
-    else
-      event_handler_hook_add (this->disabledHook);
+    event_handler_hook_add (this->eventHandlerHook);
   }
 
   void

--- a/lib/Akela-DualUse/src/Akela/DualUseMods.h
+++ b/lib/Akela-DualUse/src/Akela/DualUseMods.h
@@ -32,9 +32,8 @@
 namespace Akela {
   class DualUseMods {
   public:
-    DualUseMods (uint8_t defaultMode, uint8_t defaultAction);
-    DualUseMods (uint8_t defaultAction) : DualUseMods (Akela::Default::Off, defaultAction) {};
-    DualUseMods (void) : DualUseMods (Akela::Default::On, 1) {};
+    DualUseMods (uint8_t defaultAction);
+    DualUseMods (void) : DualUseMods (1) {};
 
     void on (void);
     void off (void);

--- a/lib/Akela-OneShot/examples/OneShot/OneShot.ino
+++ b/lib/Akela-OneShot/examples/OneShot/OneShot.ino
@@ -60,8 +60,8 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 
 };
 
-Akela::OneShotMods oneShotMods (Akela::Default::On);
-Akela::OneShotLayers oneShotLayers (Akela::Default::On);
+Akela::OneShotMods oneShotMods;
+Akela::OneShotLayers oneShotLayers;
 
 void setup () {
   oneShotMods.enableAuto ();

--- a/lib/Akela-OneShot/src/Akela/OneShotLayers.cpp
+++ b/lib/Akela-OneShot/src/Akela/OneShotLayers.cpp
@@ -163,14 +163,9 @@ namespace Akela {
 
   // --- glue code ---
 
-  OneShotLayers::OneShotLayers (uint8_t defaultState) {
-    if (defaultState == Default::Off) {
-      event_handler_hook_add (eventHandlerPassthroughHook);
-      loop_hook_add (loopNoOpHook);
-    } else {
-      event_handler_hook_add (eventHandlerHook);
-      loop_hook_add (loopHook);
-    }
+  OneShotLayers::OneShotLayers (void) {
+    event_handler_hook_add (eventHandlerHook);
+    loop_hook_add (loopHook);
   }
 
   bool

--- a/lib/Akela-OneShot/src/Akela/OneShotLayers.h
+++ b/lib/Akela-OneShot/src/Akela/OneShotLayers.h
@@ -26,8 +26,7 @@
 namespace Akela {
   class OneShotLayers {
   public:
-    OneShotLayers (uint8_t defaultState);
-    OneShotLayers (void) : OneShotLayers (Default::On) {};
+    OneShotLayers (void);
 
     static void on (void);
     static void off (void);

--- a/lib/Akela-OneShot/src/Akela/OneShotMods.cpp
+++ b/lib/Akela-OneShot/src/Akela/OneShotMods.cpp
@@ -159,14 +159,9 @@ namespace Akela {
 
   // --- glue code ---
 
-  OneShotMods::OneShotMods (uint8_t defaultState) {
-    if (defaultState == Default::Off) {
-      event_handler_hook_add (eventHandlerPassthroughHook);
-      loop_hook_add (loopNoOpHook);
-    } else {
-      event_handler_hook_add (eventHandlerHook);
-      loop_hook_add (loopHook);
-    }
+  OneShotMods::OneShotMods (void) {
+    event_handler_hook_add (eventHandlerHook);
+    loop_hook_add (loopHook);
   }
 
   bool

--- a/lib/Akela-OneShot/src/Akela/OneShotMods.h
+++ b/lib/Akela-OneShot/src/Akela/OneShotMods.h
@@ -27,8 +27,7 @@
 namespace Akela {
   class OneShotMods {
   public:
-    OneShotMods (uint8_t defaultState);
-    OneShotMods (void) : OneShotMods (Default::On) {};
+    OneShotMods (void);
 
     static void on (void);
     static void off (void);

--- a/lib/Akela-ShapeShifter/src/Akela/ShapeShifter.cpp
+++ b/lib/Akela-ShapeShifter/src/Akela/ShapeShifter.cpp
@@ -23,13 +23,10 @@ namespace Akela {
 
   static const ShapeShifter::dictionary_t *shapeShiftDictionary = NULL;
 
-  ShapeShifter::ShapeShifter (uint8_t defaultMode, const dictionary_t dictionary[]) {
+  ShapeShifter::ShapeShifter (const dictionary_t dictionary[]) {
     shapeShiftDictionary = (const dictionary_t *)dictionary;
 
-    if (defaultMode == Akela::Default::On)
-      event_handler_hook_add (this->eventHandlerHook);
-    else
-      event_handler_hook_add (this->noOpHook);
+    event_handler_hook_add (this->eventHandlerHook);
   }
 
   void

--- a/lib/Akela-ShapeShifter/src/Akela/ShapeShifter.h
+++ b/lib/Akela-ShapeShifter/src/Akela/ShapeShifter.h
@@ -28,9 +28,7 @@ namespace Akela {
       Key original, replacement;
     } dictionary_t;
 
-    ShapeShifter (uint8_t defaultMode, const dictionary_t dictionary[]);
-    ShapeShifter (const dictionary_t dictionary[])
-      : ShapeShifter (Akela::Default::On, dictionary) {};
+    ShapeShifter (const dictionary_t dictionary[]);
 
     void on (void);
     void off (void);

--- a/lib/Akela-SpaceCadet/src/Akela/SpaceCadet.cpp
+++ b/lib/Akela-SpaceCadet/src/Akela/SpaceCadet.cpp
@@ -26,14 +26,11 @@ namespace Akela {
   static const uint8_t timeOut = DEFAULT_TIMEOUT * 2;
   static Key leftParen, rightParen;
 
-  SpaceCadetShift::SpaceCadetShift (uint8_t defaultMode, Key left, Key right) {
+  SpaceCadetShift::SpaceCadetShift (Key left, Key right) {
     leftParen = left;
     rightParen = right;
 
-    if (defaultMode == Akela::Default::On)
-      event_handler_hook_add (this->eventHandlerHook);
-    else
-      event_handler_hook_add (this->noOpHook);
+    event_handler_hook_add (this->eventHandlerHook);
   }
 
   void

--- a/lib/Akela-SpaceCadet/src/Akela/SpaceCadet.h
+++ b/lib/Akela-SpaceCadet/src/Akela/SpaceCadet.h
@@ -24,10 +24,8 @@
 namespace Akela {
   class SpaceCadetShift {
   public:
-    SpaceCadetShift (uint8_t defaultMode, Key left, Key right);
-    SpaceCadetShift (uint8_t defaultMode) : SpaceCadetShift (defaultMode, Key_9, Key_0) {};
-    SpaceCadetShift (Key left, Key right) : SpaceCadetShift (Akela::Default::On, left, right) {};
-    SpaceCadetShift (void) : SpaceCadetShift (Akela::Default::On) {};
+    SpaceCadetShift (Key left, Key right);
+    SpaceCadetShift (void) : SpaceCadetShift (Key_9, Key_0) {};
 
     void on (void);
     void off (void);

--- a/lib/Akela/src/Akela.h
+++ b/lib/Akela/src/Akela.h
@@ -21,13 +21,6 @@
 #define DEFAULT_TIMEOUT 40
 
 namespace Akela {
-  namespace Default {
-    enum {
-      Off,
-      On
-    };
-  };
-
   namespace Ranges {
     enum {
       AKELA_FIRST = 0xc000,


### PR DESCRIPTION
While the `defaultMode` constructor arguments sounded nice at first, they are unnecessary complicating factors in practice. When one includes a plugin, it is reasonable to expect it will start enabled, which makes `defaultMode` pointless. As such, remove them.

Fixes #80.
