### PR TITLE
Move all configuration to a configure method

### DIFF
--- a/docs/_plugins/DualUse.md
+++ b/docs/_plugins/DualUse.md
@@ -2,7 +2,7 @@
 title: "Dual-use modifier & layer keys"
 permalink: /plugins/DualUse/
 excerpt: "Dual-use modifier and layer key plugin."
-modified: 2016-12-05T11:00:00+01:00
+modified: 2016-12-05T12:00:00+01:00
 ---
 
 {% include toc %}
@@ -27,9 +27,6 @@ tap and release them in isolation, they will act as another key instead.
 
 ```c++
 #include <Akela-DualUse.h>
-
-static Akela::DualUseMods   dualUseMods;
-static Akela::DualUseLayers dualUseLayers;
 
 // in the keymap:
 CTL_T(Esc), LT(_LAYER, Esc)
@@ -62,17 +59,20 @@ behaviour applied.
 namespace Akela {
   class DualUseMods {
   public:
-    DualUseMods (uint8_t defaultAction);
     DualUseMods (void);
+
+    static void configure (uint8_t offAction);
 
     void on (void);
     void off (void);
   };
+
   class DualUseLayers {
   public:
-    DualUseLayers (uint8_t defaultAction);
     DualUseLayers (void);
-
+    
+    static void configure (uint8_t offAction);
+    
     void on (void);
     void off (void);
   };
@@ -81,10 +81,9 @@ namespace Akela {
 
 By default, the `DualUse` plugins will start enabled, like all other plugins.
 However, when turned off, they must be aware which of the two actions they
-should perform in off state. By default, unless otherwise specified with the
-`defaultAction` constructor argument, they will perform the second action, the
+should perform in off state. By default they will perform the second action, the
 single key action. This can be changed to be the modifier or the layer switch,
-by setting `defaultAction` to zero.
+by calling the `configure` method with `offAction` set to zero.
 
 It is possible to toggle the feature on and off, with the `on()` and `off()`
 methods of the appropriate object.

--- a/docs/_plugins/Heatmap.md
+++ b/docs/_plugins/Heatmap.md
@@ -2,7 +2,7 @@
 title: "Heatmap"
 permalink: /plugins/Heatmap/
 excerpt: "LED-based Heatmap plugin."
-modified: 2016-12-01T09:30:00+01:00
+modified: 2016-12-05T12:00:00+01:00
 ---
 
 {% include toc %}
@@ -22,8 +22,6 @@ explicitly configured:
 
 ```c++
 #include <Akela-Heatmap.h>
-
-static Akela::Heatmap heatmap(500);
 ```
 
 This sets up the heatmap to update every 500 cycles, which is about 2.5 seconds,
@@ -40,13 +38,12 @@ As a general rule of thumb, the following snippet is a good starting point:
 #include <Akela-Heatmap.h>
 
 static LEDOff ledOffEffect;
-static Akela::Heatmap heatmap;
 
 // keymap declaration comes somewhere here...
 
 void setup () {
   Keyboardio.setup(KEYMAP_SIZE);
-  heatmap.activate();
+  HeatmapEffect.activate();
 }
 
 void loop () {

--- a/lib/Akela-Colormap/examples/Colormap/Colormap.ino
+++ b/lib/Akela-Colormap/examples/Colormap/Colormap.ino
@@ -83,11 +83,10 @@ const cRGB colors[] PROGMEM = {
   {0xf1, 0xf1, 0xf0},
 };
 
-static Akela::ColormapEffect colormapEffect (colors, colormap);
-
 void setup () {
   Keyboardio.setup (KEYMAP_SIZE);
-  colormapEffect.activate ();
+  ColormapEffect.configure (colors, colormap);
+  ColormapEffect.activate ();
 }
 
 void loop () {

--- a/lib/Akela-Colormap/src/Akela/Colormap.cpp
+++ b/lib/Akela-Colormap/src/Akela/Colormap.cpp
@@ -26,7 +26,11 @@ namespace Akela {
   static const uint8_t *colorMap;
   static uint32_t previousLayerState;
 
-  ColormapEffect::ColormapEffect (const cRGB _colors[], const uint8_t _colorMap[][ROWS][COLS]) {
+  ColormapEffect::ColormapEffect (void) {
+  }
+
+  void
+  ColormapEffect::configure (const cRGB _colors[], const uint8_t _colorMap[][ROWS][COLS]) {
     colors = _colors;
     colorMap = (const uint8_t *)_colorMap;
     LEDControl.mode_add (this);

--- a/lib/Akela-Colormap/src/Akela/Colormap.h
+++ b/lib/Akela-Colormap/src/Akela/Colormap.h
@@ -25,9 +25,12 @@ namespace Akela {
   public:
     static const uint8_t Transparent = 255;
 
-    ColormapEffect (const cRGB colors[], const uint8_t colorMap[][ROWS][COLS]);
+    ColormapEffect (void);
+
+    void configure (const cRGB colors[], const uint8_t colorMap[][ROWS][COLS]);
 
     virtual void update (void) final;
   };
-
 };
+
+static Akela::ColormapEffect ColormapEffect;

--- a/lib/Akela-DualUse/examples/DualUse/DualUse.ino
+++ b/lib/Akela-DualUse/examples/DualUse/DualUse.ino
@@ -40,9 +40,6 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
    ),
 };
 
-static Akela::DualUseMods dualUseMods;
-static Akela::DualUseLayers dualUseLayers;
-
 void setup () {
   Keyboardio.setup (KEYMAP_SIZE);
 }

--- a/lib/Akela-DualUse/src/Akela/DualUseLayers.cpp
+++ b/lib/Akela-DualUse/src/Akela/DualUseLayers.cpp
@@ -109,10 +109,13 @@ namespace Akela {
     return true;
   }
 
-  DualUseLayers::DualUseLayers (uint8_t defaultAction) {
-    layerDefault = !!defaultAction;
-
+  DualUseLayers::DualUseLayers (void) {
     event_handler_hook_add (eventHandlerHook);
+  }
+
+  void
+  DualUseLayers::configure (uint8_t offAction) {
+    layerDefault = !!offAction;
   }
 
   void

--- a/lib/Akela-DualUse/src/Akela/DualUseLayers.h
+++ b/lib/Akela-DualUse/src/Akela/DualUseLayers.h
@@ -27,10 +27,13 @@
 namespace Akela {
   class DualUseLayers {
   public:
-    DualUseLayers (uint8_t defaultAction);
-    DualUseLayers (void) : DualUseLayers (1) {};
+    DualUseLayers (void);
+
+    static void configure (uint8_t offAction);
 
     void on (void);
     void off (void);
   };
 };
+
+static Akela::DualUseLayers DualUseLayers;

--- a/lib/Akela-DualUse/src/Akela/DualUseMods.cpp
+++ b/lib/Akela-DualUse/src/Akela/DualUseMods.cpp
@@ -28,10 +28,13 @@ namespace Akela {
   static const uint8_t timeOut = DEFAULT_TIMEOUT * 2;
   static bool modifierDefault;
 
-  DualUseMods::DualUseMods (uint8_t defaultAction) {
-    modifierDefault = !!defaultAction;
-
+  DualUseMods::DualUseMods (void) {
     event_handler_hook_add (this->eventHandlerHook);
+  }
+
+  void
+  DualUseMods::configure (uint8_t offAction) {
+    modifierDefault = !!offAction;
   }
 
   void

--- a/lib/Akela-DualUse/src/Akela/DualUseMods.h
+++ b/lib/Akela-DualUse/src/Akela/DualUseMods.h
@@ -32,8 +32,9 @@
 namespace Akela {
   class DualUseMods {
   public:
-    DualUseMods (uint8_t defaultAction);
-    DualUseMods (void) : DualUseMods (1) {};
+    DualUseMods (void);
+
+    static void configure (uint8_t offAction);
 
     void on (void);
     void off (void);

--- a/lib/Akela-Heatmap/examples/Heatmap/Heatmap.ino
+++ b/lib/Akela-Heatmap/examples/Heatmap/Heatmap.ino
@@ -40,11 +40,9 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
   ),
 };
 
-static Akela::Heatmap heatmapEffect (500);
-
 void setup () {
   Keyboardio.setup (KEYMAP_SIZE);
-  heatmapEffect.activate ();
+  HeatmapEffect.activate ();
 }
 
 void loop () {

--- a/lib/Akela-Heatmap/src/Akela/Heatmap.cpp
+++ b/lib/Akela-Heatmap/src/Akela/Heatmap.cpp
@@ -22,7 +22,7 @@ namespace Akela {
   static uint8_t heatmap[ROWS][COLS];
   static uint16_t totalKeys;
   static uint8_t highestCount;
-  static uint16_t updateFrequency;
+  static uint16_t updateFrequency = 500;
   static uint16_t loopCount;
 
   static const float heatColors[][3] = {{0.3, 0.3, 0.3}, {0.3, 1, 0.3}, {1, 1, 0.3}, {1, 0.3, 0.3}};
@@ -63,11 +63,14 @@ namespace Akela {
     return {r, g, b};
   }
 
-  Heatmap::Heatmap (uint16_t updateFreq) {
+  Heatmap::Heatmap (void) {
     LEDControl.mode_add (this);
     event_handler_hook_add (this->eventHook);
     loop_hook_add (this->loopHook);
+  }
 
+  void
+  Heatmap::configure (uint16_t updateFreq) {
     updateFrequency = updateFreq;
   }
 

--- a/lib/Akela-Heatmap/src/Akela/Heatmap.h
+++ b/lib/Akela-Heatmap/src/Akela/Heatmap.h
@@ -23,8 +23,9 @@
 namespace Akela {
   class Heatmap : public LEDMode {
   public:
-    Heatmap (uint16_t updateFrequency);
-    Heatmap (void) : Heatmap (500) {};
+    Heatmap (void);
+
+    static void configure (uint16_t updateFrequency);
 
     virtual void update (void) final;
   private:
@@ -32,3 +33,5 @@ namespace Akela {
     static void loopHook (void);
   };
 };
+
+static Akela::Heatmap HeatmapEffect;

--- a/lib/Akela-KeyLogger/src/Akela/KeyLogger.h
+++ b/lib/Akela-KeyLogger/src/Akela/KeyLogger.h
@@ -30,4 +30,4 @@ namespace Akela {
   };
 };
 
-static Akela::KeyLogger _keyLogger;
+static Akela::KeyLogger KeyLogger;

--- a/lib/Akela-MagicCombo/examples/MagicCombo/MagicCombo.ino
+++ b/lib/Akela-MagicCombo/examples/MagicCombo/MagicCombo.ino
@@ -30,8 +30,6 @@ Akela::MagicCombo::dictionary_t dictionary[] = {
   }
 };
 
-Akela::MagicCombo exampleMagic (dictionary);
-
 const Key keymaps[][ROWS][COLS] PROGMEM = {
   [0] = KEYMAP_STACKED
   (
@@ -54,6 +52,7 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 };
 
 void setup () {
+  MagicCombo.configure (dictionary);
   Keyboardio.setup (KEYMAP_SIZE);
 }
 

--- a/lib/Akela-MagicCombo/src/Akela/MagicCombo.cpp
+++ b/lib/Akela-MagicCombo/src/Akela/MagicCombo.cpp
@@ -22,14 +22,20 @@ namespace Akela {
 
   static MagicCombo::dictionary_t *_magicDictionary = NULL;
 
-  MagicCombo::MagicCombo (dictionary_t dictionary[]) {
-    _magicDictionary = (dictionary_t *)dictionary;
-
+  MagicCombo::MagicCombo (void) {
     event_handler_hook_add (this->comboHandler);
+  }
+
+  void
+  MagicCombo::configure (const MagicCombo::dictionary_t dictionary[]) {
+    _magicDictionary = (dictionary_t *)dictionary;
   }
 
   bool
   MagicCombo::comboHandler (Key mappedKey, byte row, byte col, uint8_t keyState) {
+    if (!_magicDictionary)
+      return false;
+
     for (byte i = 0; _magicDictionary[i].callback != NULL; i++) {
       dictionary_t combo = _magicDictionary[i];
       if (KeyboardHardware.leftHandState.all == combo.leftHand &&

--- a/lib/Akela-MagicCombo/src/Akela/MagicCombo.h
+++ b/lib/Akela-MagicCombo/src/Akela/MagicCombo.h
@@ -28,9 +28,13 @@ namespace Akela {
       uint32_t leftHand, rightHand;
       comboCallback_t callback;
     } dictionary_t;
-    MagicCombo (dictionary_t dictionary[]);
+
+    MagicCombo (void);
+    static void configure (const dictionary_t dictionary[]);
 
   private:
     static bool comboHandler (Key mappedKey, byte row, byte col, uint8_t keyState);
   };
 };
+
+static Akela::MagicCombo MagicCombo;

--- a/lib/Akela-OneShot/examples/OneShot/OneShot.ino
+++ b/lib/Akela-OneShot/examples/OneShot/OneShot.ino
@@ -60,12 +60,9 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 
 };
 
-Akela::OneShotMods oneShotMods;
-Akela::OneShotLayers oneShotLayers;
-
 void setup () {
-  oneShotMods.enableAuto ();
-  oneShotLayers.enableAuto ();
+  OneShotMods.enableAuto ();
+  OneShotLayers.enableAuto ();
   Keyboardio.setup (KEYMAP_SIZE);
 }
 

--- a/lib/Akela-OneShot/src/Akela/OneShotLayers.h
+++ b/lib/Akela-OneShot/src/Akela/OneShotLayers.h
@@ -43,3 +43,5 @@ namespace Akela {
     static void loopHook (void);
   };
 };
+
+static Akela::OneShotLayers OneShotLayers;

--- a/lib/Akela-OneShot/src/Akela/OneShotMods.h
+++ b/lib/Akela-OneShot/src/Akela/OneShotMods.h
@@ -44,3 +44,5 @@ namespace Akela {
     static void loopHook (void);
   };
 };
+
+static Akela::OneShotMods OneShotMods;

--- a/lib/Akela-ShapeShifter/examples/ShapeShifter/ShapeShifter.ino
+++ b/lib/Akela-ShapeShifter/examples/ShapeShifter/ShapeShifter.ino
@@ -46,10 +46,9 @@ static const Akela::ShapeShifter::dictionary_t shapeShiftDictionary[] = {
   {Key_NoKey, Key_NoKey},
 };
 
-static Akela::ShapeShifter shapeShifter (shapeShiftDictionary);
-
 void setup () {
   Keyboardio.setup (KEYMAP_SIZE);
+  ShapeShifter.configure (shapeShiftDictionary);
 }
 
 void loop () {

--- a/lib/Akela-ShapeShifter/src/Akela/ShapeShifter.cpp
+++ b/lib/Akela-ShapeShifter/src/Akela/ShapeShifter.cpp
@@ -23,10 +23,13 @@ namespace Akela {
 
   static const ShapeShifter::dictionary_t *shapeShiftDictionary = NULL;
 
-  ShapeShifter::ShapeShifter (const dictionary_t dictionary[]) {
-    shapeShiftDictionary = (const dictionary_t *)dictionary;
-
+  ShapeShifter::ShapeShifter (void) {
     event_handler_hook_add (this->eventHandlerHook);
+  }
+
+  void
+  ShapeShifter::configure (const dictionary_t dictionary[]) {
+    shapeShiftDictionary = (const dictionary_t *)dictionary;
   }
 
   void
@@ -46,6 +49,9 @@ namespace Akela {
 
   bool
   ShapeShifter::eventHandlerHook (Key mappedKey, byte row, byte col, uint8_t keyState) {
+    if (!shapeShiftDictionary)
+      return false;
+
     // If Shift is not active, bail out early.
     if (!Keyboard.isModifierActive (Key_LShift.rawKey) &&
         !Keyboard.isModifierActive (Key_RShift.rawKey))

--- a/lib/Akela-ShapeShifter/src/Akela/ShapeShifter.h
+++ b/lib/Akela-ShapeShifter/src/Akela/ShapeShifter.h
@@ -28,7 +28,9 @@ namespace Akela {
       Key original, replacement;
     } dictionary_t;
 
-    ShapeShifter (const dictionary_t dictionary[]);
+    ShapeShifter (void);
+
+    static void configure (const dictionary_t dictionary[]);
 
     void on (void);
     void off (void);
@@ -38,3 +40,5 @@ namespace Akela {
     static bool noOpHook (Key, byte row, byte col, uint8_t keyState);
   };
 };
+
+static Akela::ShapeShifter ShapeShifter;

--- a/lib/Akela-SpaceCadet/examples/SpaceCadet/SpaceCadet.ino
+++ b/lib/Akela-SpaceCadet/examples/SpaceCadet/SpaceCadet.ino
@@ -40,8 +40,6 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
    ),
 };
 
-static Akela::SpaceCadetShift spaceCadetShift;
-
 void setup () {
   Keyboardio.setup (KEYMAP_SIZE);
 }

--- a/lib/Akela-SpaceCadet/src/Akela/SpaceCadet.cpp
+++ b/lib/Akela-SpaceCadet/src/Akela/SpaceCadet.cpp
@@ -26,11 +26,14 @@ namespace Akela {
   static const uint8_t timeOut = DEFAULT_TIMEOUT * 2;
   static Key leftParen, rightParen;
 
-  SpaceCadetShift::SpaceCadetShift (Key left, Key right) {
+  SpaceCadetShift::SpaceCadetShift () {
+    event_handler_hook_add (this->eventHandlerHook);
+  }
+
+  void
+  SpaceCadetShift::configure (Key left, Key right) {
     leftParen = left;
     rightParen = right;
-
-    event_handler_hook_add (this->eventHandlerHook);
   }
 
   void

--- a/lib/Akela-SpaceCadet/src/Akela/SpaceCadet.h
+++ b/lib/Akela-SpaceCadet/src/Akela/SpaceCadet.h
@@ -24,8 +24,9 @@
 namespace Akela {
   class SpaceCadetShift {
   public:
-    SpaceCadetShift (Key left, Key right);
-    SpaceCadetShift (void) : SpaceCadetShift (Key_9, Key_0) {};
+    SpaceCadetShift (void);
+
+    static void configure (Key left, Key right);
 
     void on (void);
     void off (void);
@@ -34,3 +35,5 @@ namespace Akela {
     static bool noOpHook (Key, byte row, byte col, uint8_t keyState);
   };
 };
+
+static Akela::SpaceCadetShift SpaceCadetShift;

--- a/lib/Akela-TapDance/examples/TapDance/TapDance.ino
+++ b/lib/Akela-TapDance/examples/TapDance/TapDance.ino
@@ -40,16 +40,14 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
    ),
 };
 
-static Akela::TapDance tapDance;
-
 static void tapDanceEsc (uint8_t tapDanceIndex, uint8_t tapCount, Akela::TapDance::ActionType tapDanceAction) {
-  tapDanceActionKeys (tapDance, tapCount, tapDanceAction, Key_Esc, Key_Tab);
+  tapDanceActionKeys (tapCount, tapDanceAction, Key_Esc, Key_Tab);
 }
 
 void tapDanceAction (uint8_t tapDanceIndex, uint8_t tapCount, Akela::TapDance::ActionType tapDanceAction) {
   switch (tapDanceIndex) {
   case 0:
-    return tapDanceActionKeys (tapDance, tapCount, tapDanceAction, Key_Tab, Key_Esc);
+    return tapDanceActionKeys (tapCount, tapDanceAction, Key_Tab, Key_Esc);
   case 1:
     return tapDanceEsc (tapDanceIndex, tapCount, tapDanceAction);
   }

--- a/lib/Akela-TapDance/src/Akela/TapDance.h
+++ b/lib/Akela-TapDance/src/Akela/TapDance.h
@@ -23,10 +23,10 @@
 
 #define TD(n) (Key){.raw = Akela::Ranges::TD_FIRST + n }
 
-#define tapDanceActionKeys(o, tapCount, tapDanceAction, ...) ({        \
-    static const Key __k[] PROGMEM = { __VA_ARGS__ };                   \
-    o.actionKeys (tapCount, tapDanceAction,                             \
-                  sizeof (__k) / sizeof (Key), &__k[0]);                \
+#define tapDanceActionKeys(tapCount, tapDanceAction, ...) ({            \
+      static const Key __k[] PROGMEM = { __VA_ARGS__ };                 \
+      TapDance.actionKeys (tapCount, tapDanceAction,                    \
+                           sizeof (__k) / sizeof (Key), &__k[0]);       \
     })
 
 namespace Akela {
@@ -56,3 +56,5 @@ namespace Akela {
 };
 
 void tapDanceAction (uint8_t tapDanceIndex, uint8_t tapCount, Akela::TapDance::ActionType tapDanceAction);
+
+static Akela::TapDance TapDance;

--- a/lib/Akela-Unicode/examples/Unicode/Unicode.ino
+++ b/lib/Akela-Unicode/examples/Unicode/Unicode.ino
@@ -40,11 +40,9 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
    ),
 };
 
-static Akela::Unicode unicode;
-
 void setup () {
   Keyboardio.setup (KEYMAP_SIZE);
-  unicode.type (0x2328);
+  Unicode.type (0x2328);
 }
 
 void loop () {

--- a/lib/Akela-Unicode/src/Akela/Unicode.cpp
+++ b/lib/Akela-Unicode/src/Akela/Unicode.cpp
@@ -26,9 +26,12 @@ namespace Akela {
 
   static Unicode::Mode inputMode;
 
-  Unicode::Unicode (Mode inputMode_) {
-    if (inputMode_ != AUTO) {
-      setMode (inputMode_);
+  Unicode::Unicode (void) {
+  }
+
+  void
+  Unicode::setup (void) {
+    if (inputMode != AUTO) {
       return;
     }
 

--- a/lib/Akela-Unicode/src/Akela/Unicode.h
+++ b/lib/Akela-Unicode/src/Akela/Unicode.h
@@ -31,8 +31,9 @@ namespace Akela {
       CUSTOM
     } Mode;
 
-    Unicode (Mode inputMode);
-    Unicode (void) : Unicode (AUTO) {};
+    Unicode (void);
+
+    static void setup (void);
 
     static void setMode (Mode inputMode);
     static Mode getMode (void);
@@ -50,3 +51,5 @@ Key hexToKey (uint8_t hex);
 void unicodeCustomStart (void);
 void unicodeCustomEnd (void);
 void unicodeCustomInput (void);
+
+static Akela::Unicode Unicode;


### PR DESCRIPTION
All of the plugins now create a static object by default, and all
configuration has been moved to `configure` methods. This makes it
easier to use the plugins when no additional configuration is needed,
and also frees the user from the burden of having to find a variable
name.

That, in turn, allows some of the thins to be simplified, like the
`tapDanceActionKeys` macro, that no longer requires an object argument:
it will use `TapDance`.

Fixes #81.