### PR TITLE
Akela-Examples: New, example-only library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,22 @@ ifeq (${VERBOSE},2)
 VERBOSE_BUILD				= -verbose
 endif
 
-EXAMPLES						= $(sort $(subst lib/Akela-,firmware/,$(wildcard lib/Akela-*)))
+FW_EXAMPLES						= $(sort $(subst lib/Akela-,firmware/,$(wildcard lib/Akela-*)))
 
-all: firmware
+EXAMPLES							= $(sort $(subst lib/Akela-Examples/examples/,examples/,$(wildcard lib/Akela-Examples/examples/*)))
 
-firmware: ${EXAMPLES}
+all: firmware examples
+
+firmware: ${FW_EXAMPLES}
 firmware/%: .FORCE
 	${MAKE} -C lib/Akela-$*/examples/$* -f ${PWD}/Mk/example.mk LIBRARY=$* SKETCH=$*
+
+examples: ${EXAMPLES}
+examples/%: .FORCE
+	${MAKE} -C lib/Akela-Examples/examples/$* -f ${PWD}/Mk/example.mk LIBRARY=Examples SKETCH=$*
 
 clean:
 	${SS} echo Cleaning in the firmwares ...
 	${SC} rm -rf firmware
 
-.PHONY: .FORCE firmware all clean
+.PHONY: .FORCE firmware examples all clean

--- a/lib/Akela-Examples/examples/AppSwitcher/AppSwitcher.ino
+++ b/lib/Akela-Examples/examples/AppSwitcher/AppSwitcher.ino
@@ -1,0 +1,59 @@
+/* -*- mode: c++ -*-
+ * Akela -- Animated Keyboardio Extension Library for Anything
+ * Copyright (C) 2016  Gergely Nagy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <KeyboardioFirmware.h>
+#include "Macros.h"
+
+const Key keymaps[][ROWS][COLS] PROGMEM = {
+  [0] = KEYMAP_STACKED
+  (
+   Key_LEDEffectNext, Key_1, Key_2, Key_3, Key_4, Key_5, Key_LEDEffectNext,
+   Key_Backtick,      Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+   Key_PageUp,        Key_A, Key_S, Key_D, Key_F, Key_G,
+   Key_PageDn,        Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Esc,
+
+   Key_LCtrl, Key_Backspace, Key_LGUI, Key_LShift,
+   M(M_APPSWITCH),
+
+   Key_skip,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+   Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
+              Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
+   Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+
+   Key_RShift, Key_RAlt, Key_Space, Key_RCtrl,
+   M(M_APPCANCEL)
+   ),
+};
+
+const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
+  switch (macroIndex) {
+  case M_APPSWITCH:
+    return macroAppSwitch (keyState);
+  case M_APPCANCEL:
+    return macroAppCancel (keyState);
+  }
+  return MACRO_NONE;
+}
+
+void setup () {
+  Keyboardio.setup (KEYMAP_SIZE);
+}
+
+void loop () {
+  Keyboardio.loop ();
+}

--- a/lib/Akela-Examples/examples/AppSwitcher/Macros.cpp
+++ b/lib/Akela-Examples/examples/AppSwitcher/Macros.cpp
@@ -1,0 +1,56 @@
+/* -*- mode: c++ -*-
+ * Akela -- Animated Keyboardio Extension Library for Anything
+ * Copyright (C) 2016  Gergely Nagy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define AKELA_HOSTOS_GUESSER 1
+
+#include <Akela-HostOS.h>
+
+#include "Macros.h"
+
+using namespace Akela::HostOS;
+
+static bool appSwitchActive = false;
+
+const macro_t *macroAppSwitch (uint8_t keyState) {
+  Key mod = Key_LAlt;
+
+  if (HostOS.os () == OSX)
+    mod = Key_LGUI;
+
+  // Key was just pressed, or is being held
+  if (key_is_pressed(keyState)) {
+    return MACRO(Dr(mod), D(Tab), END);
+  }
+  // Key was just released
+  if (key_toggled_off(keyState)) {
+    return MACRO(U(Tab), Dr(mod), END);
+  }
+  // Key is not pressed, and was not just released.
+  // if appSwitchActive is true, we continue holding Alt.
+  if (appSwitchActive) {
+    return MACRO(Dr(mod), END);
+  }
+  // otherwise we do nothing
+  return MACRO_NONE;
+}
+
+const macro_t *macroAppCancel (uint8_t keyState) {
+  if (key_toggled_on (keyState))
+    appSwitchActive = false;
+  return MACRO_NONE;
+}

--- a/lib/Akela-Examples/examples/AppSwitcher/Macros.h
+++ b/lib/Akela-Examples/examples/AppSwitcher/Macros.h
@@ -1,0 +1,29 @@
+/* -*- mode: c++ -*-
+ * Akela -- Animated Keyboardio Extension Library for Anything
+ * Copyright (C) 2016  Gergely Nagy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <Keyboardio-Macros.h>
+
+enum {
+  M_APPSWITCH,
+  M_APPCANCEL,
+};
+
+const macro_t *macroAppSwitch (uint8_t keyState);
+const macro_t *macroAppCancel (uint8_t keyState);

--- a/lib/Akela-Examples/library.properties
+++ b/lib/Akela-Examples/library.properties
@@ -1,0 +1,9 @@
+name=Akela-Examples
+version=0.0.0
+author=Gergely Nagy
+maintainer=Gergely Nagy <akela@gergo.csillger.hu>
+sentence=Example Sketches for Akela.
+paragraph=Examples that span multiple Akela plugins, in a reusable form.
+category=Communication
+url=https://github.com/algernon/Akela
+architectures=avr

--- a/lib/Akela-Examples/src/Akela-Examples.h
+++ b/lib/Akela-Examples/src/Akela-Examples.h
@@ -1,0 +1,17 @@
+/* -*- mode: c++ -*-
+ * Akela -- Animated Keyboardio Extension Library for Anything
+ * Copyright (C) 2016  Gergely Nagy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */


### PR DESCRIPTION
This library is meant to collect examples that span plugins. Most of the stuff implemented herein should be easy to reuse.
